### PR TITLE
Set Memorized Numbers View Model function refactor

### DIFF
--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -313,6 +313,8 @@ namespace CalculatorApp
 
         private:
             void SetMemorizedNumbers(const std::vector<std::wstring>& memorizedNumbers);
+            void UpdateMemorizedNumbers(const std::vector<std::wstring>& newMemorizedNumbers) 
+            void PushNewValueMemorizedNumbers(std::wstring stringValue);
             void UpdateProgrammerPanelDisplay();
             void HandleUpdatedOperandData(CalculationManager::Command cmdenum);
             NumbersAndOperatorsEnum ConvertIntegerToNumbersAndOperatorsEnum(unsigned int parameter);


### PR DESCRIPTION
## Fixes #.
In the function "SetMemorizedNumbers" in StandardCalcuatorViewModel, the logic was split up into multiple helper functions.

### Description of the changes:
- added helper function to update the new stack of memorized numbers with the actual one
- added helper function to add a new item to the memorized numbers stack
- split up the logic in SetMemorizedNumbers into helper funtions

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.
Use the set memory function as intended, also prebuilt unit tests are passing. 

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
1) startup calcuator.exe
2) press in any number
3) press MS
4) press CE
5) press MR
6) numbers should match in step 1

